### PR TITLE
[WL-958] Transaction fee bug

### DIFF
--- a/apps/wallet/src/features/Send/InputTransaction/TransactionFee/AbstractedTransactionFee.tsx
+++ b/apps/wallet/src/features/Send/InputTransaction/TransactionFee/AbstractedTransactionFee.tsx
@@ -28,6 +28,8 @@ interface Props {
 	tokenList: TokenDocument[];
 }
 
+let feeRequestID = 0;
+
 export const AbstractedTransactionFee: FC<Props> = ({ tokenList }) => {
 	const [isFeeLoading, setIsFeeLoading] = useState(false);
 	const [error, setError] = useState('');
@@ -84,13 +86,21 @@ export const AbstractedTransactionFee: FC<Props> = ({ tokenList }) => {
 			};
 
 			setIsFeeLoading(true);
-			const fee = await requestTransactionFee(payload);
+
+			const { fee, requestID } = await requestTransactionFee(
+				payload,
+				feeRequestID,
+			);
+			if (requestID !== feeRequestID) return;
+			feeRequestID++;
+
 			const decimals = payload.tokenForFee?.account?.decimals;
 			txActions.update({
 				transactionFee: parseFloat(fee.toPrecision(decimals)),
 			});
 			setIsFeeLoading(false);
 		};
+
 		updateTransactionFee();
 	}, [tokenForFee, token, collectible, receiver]);
 

--- a/apps/wallet/src/features/Send/InputTransaction/TransactionFee/AbstractedTransactionFee.tsx
+++ b/apps/wallet/src/features/Send/InputTransaction/TransactionFee/AbstractedTransactionFee.tsx
@@ -28,8 +28,6 @@ interface Props {
 	tokenList: TokenDocument[];
 }
 
-let currentTokenForFeeMint: string = '';
-
 export const AbstractedTransactionFee: FC<Props> = ({ tokenList }) => {
 	const [isFeeLoading, setIsFeeLoading] = useState(false);
 	const [error, setError] = useState('');
@@ -87,9 +85,8 @@ export const AbstractedTransactionFee: FC<Props> = ({ tokenList }) => {
 
 			setIsFeeLoading(true);
 
-			currentTokenForFeeMint = payload.tokenForFee?.account?.mint as string;
 			const { fee, feeTokenMint } = await requestTransactionFee(payload);
-			if (feeTokenMint !== currentTokenForFeeMint) return;
+			if (feeTokenMint !== txContext.tx.tokenForFee?.account.mint) return;
 
 			const decimals = payload.tokenForFee?.account?.decimals;
 			txActions.update({

--- a/apps/wallet/src/features/Send/InputTransaction/TransactionFee/AbstractedTransactionFee.tsx
+++ b/apps/wallet/src/features/Send/InputTransaction/TransactionFee/AbstractedTransactionFee.tsx
@@ -28,7 +28,7 @@ interface Props {
 	tokenList: TokenDocument[];
 }
 
-let feeRequestID = 0;
+let currentTokenForFeeMint: string = '';
 
 export const AbstractedTransactionFee: FC<Props> = ({ tokenList }) => {
 	const [isFeeLoading, setIsFeeLoading] = useState(false);
@@ -87,12 +87,9 @@ export const AbstractedTransactionFee: FC<Props> = ({ tokenList }) => {
 
 			setIsFeeLoading(true);
 
-			const { fee, requestID } = await requestTransactionFee(
-				payload,
-				feeRequestID,
-			);
-			if (requestID !== feeRequestID) return;
-			feeRequestID++;
+			currentTokenForFeeMint = payload.tokenForFee?.account?.mint as string;
+			const { fee, feeTokenMint } = await requestTransactionFee(payload);
+			if (feeTokenMint !== currentTokenForFeeMint) return;
 
 			const decimals = payload.tokenForFee?.account?.decimals;
 			txActions.update({

--- a/apps/wallet/src/features/Send/InputTransaction/TransactionFee/internal.ts
+++ b/apps/wallet/src/features/Send/InputTransaction/TransactionFee/internal.ts
@@ -10,13 +10,15 @@ import { txActions } from '../../context';
 
 export const requestTransactionFee = async (
 	payload: TransactionPayload,
-	requestID: number,
-) => {
+): Promise<{
+	fee: number;
+	feeTokenMint: string;
+}> => {
 	if (payload.receiver === '') {
 		txActions.update({ transactionFee: 0 });
 		return {
 			fee: 0,
-			requestID,
+			feeTokenMint: payload.tokenForFee?.account?.mint || '',
 		};
 	}
 
@@ -27,12 +29,12 @@ export const requestTransactionFee = async (
 				: await getTransactionFee(payload);
 		return {
 			fee,
-			requestID,
+			feeTokenMint: payload.tokenForFee?.account?.mint || '',
 		};
 	} catch {
 		return {
 			fee: 0,
-			requestID,
+			feeTokenMint: payload.tokenForFee?.account?.mint || '',
 		};
 	}
 };

--- a/apps/wallet/src/features/Send/InputTransaction/TransactionFee/internal.ts
+++ b/apps/wallet/src/features/Send/InputTransaction/TransactionFee/internal.ts
@@ -67,7 +67,7 @@ export const getTokenName = (
 		if (tokenForFee && tokenForFee.metadata?.symbol) {
 			return tokenForFee.metadata.symbol;
 		} else {
-			return 'SOL';
+			return 'Unknown';
 		}
 	} else if (network == Networks.sui) {
 		return 'SUI';

--- a/apps/wallet/src/features/Send/InputTransaction/TransactionFee/internal.ts
+++ b/apps/wallet/src/features/Send/InputTransaction/TransactionFee/internal.ts
@@ -8,10 +8,16 @@ import {
 
 import { txActions } from '../../context';
 
-export const requestTransactionFee = async (payload: TransactionPayload) => {
+export const requestTransactionFee = async (
+	payload: TransactionPayload,
+	requestID: number,
+) => {
 	if (payload.receiver === '') {
 		txActions.update({ transactionFee: 0 });
-		return 0;
+		return {
+			fee: 0,
+			requestID,
+		};
 	}
 
 	try {
@@ -19,9 +25,15 @@ export const requestTransactionFee = async (payload: TransactionPayload) => {
 			payload.tokenForFee?.metadata?.symbol !== 'SOL'
 				? await getTransactionAbstractFee(payload)
 				: await getTransactionFee(payload);
-		return fee;
+		return {
+			fee,
+			requestID,
+		};
 	} catch {
-		return 0;
+		return {
+			fee: 0,
+			requestID,
+		};
 	}
 };
 

--- a/apps/wallet/src/modals/SendToken.tsx
+++ b/apps/wallet/src/modals/SendToken.tsx
@@ -49,6 +49,8 @@ export const showSendTokenModal = (props: SendFeatureProps) => {
 		bindingDirection: BindDirections.InnerBottom,
 		animateDirection: AnimateDirections.Top,
 		fullHeight: true,
+		maskActiveOpacity: 0.1,
+		positionOffset: { y: 32 },
 		component: ({ config }) => <SendModal config={config} props={props} />,
 	});
 };

--- a/packages/gui/components/ModalManager/ModalContainer.tsx
+++ b/packages/gui/components/ModalManager/ModalContainer.tsx
@@ -78,6 +78,11 @@ export const ModalContainer: FC<Props> = ({ item }) => {
 		if (fullHeight) {
 			baseStyle.height = height.value;
 			baseStyle.bottom = 0;
+
+			if (positionOffset?.y && positionOffset.y > 0) {
+				baseStyle.height -= positionOffset.y;
+				baseStyle.top = positionOffset.y;
+			}
 		}
 
 		return rectangleAnimatedStyle(opacity, item.animateDirection, baseStyle);


### PR DESCRIPTION
# README

## Reproduce

1. Open send modal in Solana layout
2. Enter recipient address (aka `receiver`)
3. Select `USDC Dev` as our send token
4. Select `USDC Dev` as our fee token
5. Select `SOL` as our send token ==> Boom, here the bug comes

Expected behavior: The fee is set to SOL fee (e.g. `0.00005 SOL`)

Actual behavior: The fee is set to SOL fee (e.g. `0.00005 SOL`), then it is immediately set with the USDC Dev fee (`0` in this case as our call to Gasilon API failed `{status: "error", message: ""}`, I don't know what type of this bug due to empty response message)

## Why we have this bug?

Our `requestTransactionFee` is called inside a `useEffect` which has dependencies of `tokenForFee, token, collectible, receiver`.

When we set the send token back to `SOL`, the fee token is also set back from `USDC Dev` to `SOL` => `useEffect` called twice here

Promise 1 (run first): `useEffect` is called due to the change of `token` dependency
Promise 2 (run after): `useEffect` is called due to the change of `tokenForFee` dependency

Somehow, Promise 2 (the one called Solana SDK method) run faster than Promise 1 (the one fetched to Gasilon)
=> Fee transits from `0.18xxx USDC Dev` (before bug trigger action) -> `0.00005 Sol` -> `0 USDC Dev`

## Solution

### `AbortController`

I've tried to use [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) but it only works for `fetch` API through a `signal` arg.
Since our `requestTransactionFee` gets the fee from two ways:
- [x] Gasilon API (can be aborted as we fetch directly to Gasilon endpoint)
- [ ] Solana SDK method (cannot be aborted as they do not expose any signal)

=> It seems like we cannot use `AbortController` in this case

### `throttle` | `debounce`

Another option that we have discussed is applying `throttle` or `debounce` from `lodash` but I don't think it can solve this case (if you have any ideas, please help me)

### Remove `token` dependency

What if we can remove the `token` from the dependency list? It will solve the problem easily.

But there is a case, is there any network that has different gas fee for different tokens (e.g. fee when sending `SUI` is 1$, fee when sending other tokens is 2$)? If this is a case, we cannot remove the `token` dependency.

### Request ID

See the files changed