### PR TITLE
feat: extension store blue argon remover via webpack

### DIFF
--- a/apps/wallet/browser/bundler/webpack.js
+++ b/apps/wallet/browser/bundler/webpack.js
@@ -1,5 +1,6 @@
 const { resolve } = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
+const ReplaceInFilePlugin = require('replace-in-file-webpack-plugin');
 
 const isProd = process.env.ENV === 'production';
 const isExtension = process.env.BUILD_TARGET === 'extension';
@@ -130,6 +131,37 @@ const injectEnvironments = (config, internal) => {
 	return config;
 };
 
+const replaceExtensionArgonLinks = (config) => {
+	if (isExtension) {
+		config.plugins.push(
+			new ReplaceInFilePlugin([
+				{
+					dir: 'metacraft',
+					test: [/app.js(\.map)?$/],
+					rules: [
+						{
+							search: 'https://apis.google.com/js/api.js',
+							replace: '',
+						},
+						{
+							search: 'https://www.googletagmanager.com/gtag/js',
+							replace: '',
+						},
+					],
+				},
+			]),
+		);
+	}
+
+	return config;
+};
+
+const minifyOption = {
+	compress: true,
+	mangle: true,
+	format: { comments: false },
+};
+
 const swcOptions = () => ({
 	jsc: {
 		parser: {
@@ -137,15 +169,7 @@ const swcOptions = () => ({
 			tsx: true,
 			dynamicImport: true,
 		},
-		minify: isProd
-			? {
-					compress: true,
-					mangle: true,
-					format: {
-						comments: false,
-					},
-				}
-			: {},
+		minify: isProd ? {} : minifyOption,
 	},
 	env: {
 		targets: {
@@ -166,4 +190,5 @@ module.exports = {
 	registerExtFile,
 	buildOptimization,
 	injectEnvironments,
+	replaceExtensionArgonLinks,
 };

--- a/apps/wallet/metacraft.config.js
+++ b/apps/wallet/metacraft.config.js
@@ -6,6 +6,7 @@ const {
 	registerExtFile,
 	injectEntries,
 	injectEnvironments,
+	replaceExtensionArgonLinks,
 } = require('./browser/bundler/webpack');
 
 module.exports = {
@@ -19,6 +20,7 @@ module.exports = {
 		registerExtFile,
 		injectEntries,
 		injectEnvironments,
+		replaceExtensionArgonLinks,
 	],
 	devMiddlewares: [w3aDevRoute],
 	htmlPluginOptions: {

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -10,13 +10,11 @@
     "build:all": "yarn build:ext && yarn build:web",
     "build:web": "rimraf metacraft builds && metacraft bundle",
     "build:ext": "BUILD_TARGET=extension && yarn build:web && node browser/bundler",
-    "build:store": "BUILD_TARGET=extension && yarn build:web && yarn badlinks && node browser/bundler",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "start": "react-native start",
     "postinstall": "rm -rf node_modules/superstruct",
-    "badlinks": "npx badlinks metacraft -r",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
@@ -114,6 +112,7 @@
     "jest": "^29.4.3",
     "pouchdb-adapter-memory": "^8.0.1",
     "react-test-renderer": "18.2.0",
+    "replace-in-file-webpack-plugin": "^1.0.6",
     "rimraf": "5.0.5"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11808,6 +11808,7 @@ __metadata:
     react-native-vision-camera: ^3.9.0
     react-native-webview: 13.6.3
     react-test-renderer: 18.2.0
+    replace-in-file-webpack-plugin: ^1.0.6
     rimraf: 5.0.5
     use-debounce: ^10.0.0
   peerDependencies:
@@ -24552,6 +24553,13 @@ __metadata:
     lodash: ^4.17.21
     strip-ansi: ^6.0.1
   checksum: 77162b62d6f33ab81f337c39efce0439ff0d1f6d441e29c35183151f83041c7850774fb904da163d6c844264d440d10557714e6daa0b19e4561a5cd4ef305d41
+  languageName: node
+  linkType: hard
+
+"replace-in-file-webpack-plugin@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "replace-in-file-webpack-plugin@npm:1.0.6"
+  checksum: 0c00a074e544ebe1aef0615e594f6daad47427950a2454e88f94dcb185839d68ce07854b83bbcb5f9b2336f8e8ae24017db4eca085135a9be84e43585163301a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Google Extension store's review reject bundled `app.js` if there is tracking link inside the source code, no matter we use it or not; then, one of the suggested way is to remove/replace them with `''` to prove that our Extension compliance with a policy they called `bue argons`.