### PR TITLE
hotfix: content script run behind wallet detect event

### DIFF
--- a/apps/wallet/browser/bundler/manifest.json
+++ b/apps/wallet/browser/bundler/manifest.json
@@ -43,6 +43,7 @@
         "http://*/*",
         "https://*/*"
       ],
+	  "run_at": "document_start",
       "all_frames": true
     }
   ],


### PR DESCRIPTION
Bug: content script run behind wallet detect event -> unable to detect Walless
Solution: add 'run_at: document_start' to content script in manifest.json